### PR TITLE
Fix cpx command

### DIFF
--- a/firebase-functions-es6-babel/package.json
+++ b/firebase-functions-es6-babel/package.json
@@ -24,7 +24,7 @@
     "deploy": "yarn firebase deploy --only functions",
     "clean": "rimraf 'dist/functions'",
     "build:funcs": "babel 'src/functions' --out-dir 'dist/functions'",
-    "deps:copy": "cpx *{package.json,yarn.lock} 'dist/functions'",
+    "deps:copy": "cpx '*{package.json,yarn.lock}' 'dist/functions'",
     "deps:install": "cd 'dist/functions' && yarn"
   },
   "dependencies": {


### PR DESCRIPTION
Error described here:
https://github.com/jthegedus/blog-code/issues/4

This PR fixes, that yarn deps:copy fails due to missing quotes for the first parameter.